### PR TITLE
added city configuration file - see README. Removed -G option code

### DIFF
--- a/README.md
+++ b/README.md
@@ -38,11 +38,11 @@ Parts I purchased:
 
 ```
   -d                : Layout is down vs left/right
-  -d [d|l]        : Layout is:  D(own) or L(eft/right)
+  -d [d|l]          : Layout is:  D(own) or L(eft/right)
   -c                : Show city name vs airport code
   -s <spacing>      : Gap to replace space in time with in pixels (Default: 2)
-  -G <spacing>      : Gap between columns in pixels (Default: 4)
   -F <date-format>  : Date format (Default is HH:MM:SS via %H:%M:%S)
+  -C city-file      : city config filename
 ```
 
 If you are using a wide display (or two panels left-right) then it paints left right.

--- a/cities.txt
+++ b/cities.txt
@@ -1,0 +1,16 @@
+#
+# Whatever you want to show!
+#
+
+	Africa/Johannesburg	JNB
+	America/Denver		DEN
+	America/Los_Angeles	SEA
+	America/New_York	NYC
+#	Pacific/Auckland	AKL
+	Asia/Kolkata		BLR
+#	Asia/Hong_Kong		HKG
+	Asia/Singapore		SIN	# RPi fun - Singapore does not have a timezone name (but it should be SGT)
+	Asia/Tel_Aviv		TLV
+	Europe/London		LHR
+	Europe/Paris		EUR
+

--- a/configuration.cc
+++ b/configuration.cc
@@ -5,13 +5,14 @@
 #include "configuration.h"
 
 #include <string.h>
+#include <fstream>
 #include <time.h>
 #include <unistd.h>
 #include <bits/stdc++.h>
 
 using namespace rgb_matrix;
 
-const TZDataWanted tz_wanted[] = {
+const TZDataWanted tz_wanted_built_in[] = {
 //	{ "Africa/Johannesburg", "JNB"},
 	{ "America/Denver",      "DEN"},
 	{ "America/Los_Angeles", "SEA"},
@@ -25,4 +26,62 @@ const TZDataWanted tz_wanted[] = {
 	{ "Europe/Paris",        "EUR"}		// "EUR" for Europe vs the specific city
 };
 
-const size_t tz_wanted_len = sizeof(tz_wanted)/sizeof(tz_wanted[0]);
+const size_t tz_wanted_len_built_in = sizeof(tz_wanted_built_in)/sizeof(tz_wanted_built_in[0]);
+
+TZDataWanted *tz_wanted = (TZDataWanted *)tz_wanted_built_in;
+size_t tz_wanted_len = sizeof(tz_wanted_built_in)/sizeof(tz_wanted_built_in[0]);
+
+#define	MAX_ENTRIES	100
+
+size_t read_city_list(const char *filename)
+{
+	std::fstream f;
+
+	// if no file passed - we are still ok with built in list
+	if (filename == NULL || strlen(filename) == 0) {
+		return tz_wanted_len;
+	}
+
+	// hopefully read the cities.txt file - if not, we have a list above to fall back on
+	f.open(filename);
+	if (!f.is_open()) {
+		return 0;
+	}
+
+	TZDataWanted *p = (TZDataWanted *)malloc(sizeof(TZDataWanted)*(MAX_ENTRIES+1));
+	size_t n = 0;
+	std::string my_line;
+
+	while (!f.eof()) {
+		if (n >= MAX_ENTRIES)
+			break;
+		std::getline(f, my_line);
+		if (my_line.length() == 0 || my_line[0] == '#')
+			continue;
+
+		char *line_timezone = NULL;
+		char *line_cityname = NULL;
+		char *token = strtok((char *)my_line.c_str(), " \t");
+		if (token != NULL) {
+			line_cityname = token;
+			token = strtok(NULL, " \t");
+			if (token != NULL) {
+				line_timezone = token;
+			}
+		}
+
+		// Store away
+		p[n].tzString = strdup(line_cityname);
+		p[n].tzDisplay = strdup(line_timezone);
+
+		n++;
+	}
+	f.close();
+        p[n].tzString = NULL;
+        p[n].tzDisplay = NULL;
+
+	tz_wanted = p;
+	tz_wanted_len = n;
+
+	return n;
+}

--- a/configuration.h
+++ b/configuration.h
@@ -18,5 +18,8 @@ struct TZDataWanted {
 	const char *tzDisplay;
 }; 
 
-extern const TZDataWanted tz_wanted[];
-extern const size_t tz_wanted_len;
+extern TZDataWanted *tz_wanted;
+extern size_t tz_wanted_len;
+
+extern size_t read_city_list(const char *filename);
+


### PR DESCRIPTION
The example city list. is defined in `cities.txt` file. This can be edited. It's two columns, the timezone name and the three letter airport code to display. If not file is specified, then the built in list is used.

Plus some other cleanup.
   